### PR TITLE
Set `SLInitHook.x64=0` in .ini file to fix Easy Print

### DIFF
--- a/bin/autoupdate.bat
+++ b/bin/autoupdate.bat
@@ -245,8 +245,8 @@ if exist %rdpwrap_new_ini% (
     echo     -^> %rdpwrap_ini_url% 
     echo       -^> %rdpwrap_new_ini%
     echo         -^> %rdpwrap_ini%
-    echo [+] copy %rdpwrap_new_ini% to %rdpwrap_ini%...
-    copy %rdpwrap_new_ini% %rdpwrap_ini%
+    echo [+] copy %rdpwrap_new_ini% to %rdpwrap_ini% and set `SLInitHook.x64=0`...
+    powershell -Command "(gc '%rdpwrap_new_ini%') -replace 'SLInitHook.x64=1', 'SLInitHook.x64=0' | Out-File -encoding ASCII '%rdpwrap_ini%'"
     echo.
 ) else (
     echo [x] ERROR - File %rdpwrap_new_ini% is missing ^^!


### PR DESCRIPTION
Remote printing only works if the host has exactly the same printer driver installed as the client.

The Remote Desktop Easy Print driver is supposed to make any remote printer work. But with rdpwrap installed this driver is not used.

https://github.com/stascorp/rdpwrap/issues/874 mentions a solution / workaround: set `SLInitHook.x64=0`. This works for me.

I have no clue what `SLInitHook` does and if this change has any undesired effects.